### PR TITLE
Allow full paths for the report filename.

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,9 +21,9 @@ module.exports = (api, projectOptions) => {
     if(process.env.VUE_CLI_MODERN_MODE === "true") {
       const isModernBuild = process.env.VUE_CLI_MODERN_BUILD === "true";
       const normalizedReportFilename = mergedOptions.reportFilename || "report.html";
-      const pathParts = normalizedReportFilename.split( '/' );
+      const pathParts = normalizedReportFilename.split("/");
       const reportFilename = pathParts.pop();
-      const path = ( pathParts.length > 0 ? pathParts.join( '/' ) + '/' : '');
+      const path = pathParts.length > 0 ? pathParts.join("/") + "/" : "";
       mergedOptions.reportFilename = path + (isModernBuild ? "modern-" : "legacy-") + reportFilename;
     }
 

--- a/index.js
+++ b/index.js
@@ -20,8 +20,11 @@ module.exports = (api, projectOptions) => {
   api.chainWebpack(webpackConfig => {
     if(process.env.VUE_CLI_MODERN_MODE === "true") {
       const isModernBuild = process.env.VUE_CLI_MODERN_BUILD === "true";
-      const reportFilename = mergedOptions.reportFilename || "report.html";
-      mergedOptions.reportFilename = (isModernBuild ? "modern-" : "legacy-") + reportFilename;
+      const normalizedReportFilename = mergedOptions.reportFilename || "report.html";
+      const pathParts = normalizedReportFilename.split( '/' );
+      const reportFilename = pathParts.pop();
+      const path = ( pathParts.length > 0 ? pathParts.join( '/' ) + '/' : '');
+      mergedOptions.reportFilename = path + (isModernBuild ? "modern-" : "legacy-") + reportFilename;
     }
 
     webpackConfig


### PR DESCRIPTION
Since this plugin prepends 'modern-' or 'legacy-' to the filename without regard to the path that might be present, the files _have_ to go in the outputDir, whereas someone may want them being put somewhere else, outside of the build output files.
This commit pull off the filename and reuses the path provided (if any) when setting the report filename.